### PR TITLE
Prefer a deck name from command options over generated from a markdown file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # MDAnki Changelog
 
+#### v1.0.2 - 2020.02.21
+* Prefer the explicit deck name over calculated ([#2](https://github.com/ashlinchak/mdanki/pull/2))
+
 #### v1.0.1 - 2020.02.21
 * Add tests ([#1](https://github.com/ashlinchak/mdanki/pull/1))
 * Fix minor bugs ([#1](https://github.com/ashlinchak/mdanki/pull/1))

--- a/__tests__/transformer.test.js
+++ b/__tests__/transformer.test.js
@@ -48,7 +48,7 @@ describe('Transformer', () => {
     describe('parse a directory', () => {
       beforeEach(() => {
         jest.spyOn(Transformer.prototype, 'addResourcesToDeck').mockImplementation();
-        jest.spyOn(Transformer.prototype, 'defaultDeckName').mockReturnValue('deck name');
+        jest.spyOn(Transformer.prototype, 'calculateDeckName').mockReturnValue('deck name');
         jest.spyOn(Deck.prototype, 'save').mockResolvedValue({
           save: jest.fn(),
         });
@@ -97,7 +97,7 @@ describe('Transformer', () => {
       });
 
       test('sets a deck name based on the title from the markdown', () => {
-        expect(transformer.deck.name).toEqual('Deck title');
+        expect(transformer.deck.name).toEqual('deck name');
       });
     });
 
@@ -126,7 +126,7 @@ describe('Transformer', () => {
     });
   });
 
-  describe('#defaultDeckName', () => {
+  describe('#calculateDeckName', () => {
     beforeEach(() => {
       jest.resetModules();
     });
@@ -139,8 +139,20 @@ describe('Transformer', () => {
       transformer = new Transformer(sourceFilePath, 'anki.apkg');
 
       expect(
-        transformer.defaultDeckName(),
+        transformer.calculateDeckName(),
       ).toEqual('deck name');
+    });
+
+    test('generates deck name from markdown title', () => {
+      jest.mock('yargs', () => ({
+        argv: { deck: null },
+      }));
+      Transformer = require('../src/transformer');
+      transformer = new Transformer(sourceFilePath, 'anki.apkg');
+
+      expect(
+        transformer.calculateDeckName('calculated deck name'),
+      ).toEqual('calculated deck name');
     });
 
     test('generates deck name from default configs', () => {
@@ -151,7 +163,7 @@ describe('Transformer', () => {
       transformer = new Transformer(sourceFilePath, 'anki.apkg');
 
       expect(
-        transformer.defaultDeckName(),
+        transformer.calculateDeckName(),
       ).toEqual('mdanki');
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdanki",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdanki",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Convert markdown files to anki cards",
   "keywords": [
     "anki",

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -86,19 +86,18 @@ class Transformer {
       process.exit(1);
     }
 
-    this.deck = new Deck(deckName || this.defaultDeckName());
+    this.deck = new Deck(this.calculateDeckName(deckName));
 
     await this.exportCards(cards, media);
   }
 
   /**
+   * @param {string} generatedName
    * @returns {string} Default deck name
    * @private
    */
-  defaultDeckName() {
-    if (argv.deck) { return argv.deck; }
-
-    return configs.deck.defaultName;
+  calculateDeckName(generatedName = null) {
+    return argv.deck || generatedName || configs.deck.defaultName;
   }
 
   /**


### PR DESCRIPTION
If a deck name is set from the command line options explicitly it should be preferred over calculated during the parsing Markdown file.
```bash
mdanki file.md anki.apkg --deck "Deck Name"
```