### PR TITLE
Add feature: support default tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,17 +104,22 @@ Cards can have tags in their markdown sources. For adding tags to cart it should
 * only one line with tags per card
 * a tag should be written in the link format
 * tag (link text) should start from `#` symbol
+* tag should not contain empty string
+* tags under deck name will be default tags
 
 MDAnki uses `'^\\[#(.*)\\]'` pattern for searching tags. This pattern could be overwritten by specifying custom settings. The source file in the tag link is optional.
 
-The below example will generate a card with 3 tags: _algorithms_, _OOP_, and _binary_tree_.
+The below example will generate a card with 4 tags: _algorithms_, _OOP_, _binary_tree_, and _default_tag_.
 
 ```
+# deck name
+[#default_tag]()
+
 ## Binary tree
 
 In computer science, a binary tree is a tree data structure in which each node has at most two children, which are referred to as the left child and the right child.
 
-[#algorithms](./algorityms.md) [#OOP]() [#binary tree]()
+[#algorithms](./algorityms.md) [#OOP]() [#binary_tree]()
 ```
 
 ## Code and syntax highlighting

--- a/__tests__/file_serializer.test.js
+++ b/__tests__/file_serializer.test.js
@@ -44,6 +44,19 @@ describe('FileSerializer', () => {
       expect(media[0].fileName).toEqual('8d777f385d3dfec8815d20f7496026dc.png');
     });
 
+    test('find first deckName', async () => {
+      markdown = `# Deck name\n[#tag2]()\n## Title\nbody\n[#tag]()`;
+      serializer = new FileSerializer(filePath);
+
+      const { deckName, cards } = await serializer.transform();
+
+      expect(deckName).toEqual('Deck name');
+      expect(cards.length).toEqual(1);
+      expect(cards[0].tags[0]).toEqual('tag');
+      expect(cards[0].tags[1]).toEqual('tag2');
+    });
+
+
     test('returns without a deck name if it\'s not specified in the markdown', async () => {
       markdown = `## Title\nbody\n![media](${mediaPath})`;
       serializer = new FileSerializer(filePath);


### PR DESCRIPTION
Cards on the same markdown file can have default tags.
The default tags are under deck name, upper on all of the cards.

```
# Deck name

[#default_tag]()

## card

blabla
```